### PR TITLE
Chapter1ではblue imageのアプリケーションのみデプロイするよう変更

### DIFF
--- a/chapter01_cluster-create/README.md
+++ b/chapter01_cluster-create/README.md
@@ -162,7 +162,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 ## アプリケーションのデプロイ
 次章以降で使用する動作確認用アプリケーションとして、[Argo Rollouts Demo Application](https://github.com/argoproj/rollouts-demo)をデプロイします。
 
-```sh
+```shell
 kubectl create namespace handson
 kubectl apply -f manifest/app/serviceaccount.yaml -n handson -l color=blue
 kubectl apply -f manifest/app/deployment.yaml -n handson -l color=blue
@@ -172,10 +172,10 @@ kubectl apply -f manifest/app/ingress.yaml -n handson
 
 作成されるリソースは下記のとおりです。
 
-```sh
+```shell
 kubectl get services,deployments,ingresses -n handson
 ```
-```sh
+```shell
 # 実行結果
 NAME              TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 service/handson   ClusterIP   10.96.82.202   <none>        8080/TCP   3m33s

--- a/chapter01_cluster-create/README.md
+++ b/chapter01_cluster-create/README.md
@@ -164,13 +164,27 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 
 ```shell
 kubectl create namespace handson
-kubectl apply -Rf manifest/app -n handson
+kubectl apply -f manifest/app/serviceaccount.yaml -n handson -l color=blue
+kubectl apply -f manifest/app/deployment.yaml -n handson -l color=blue
+kubectl apply -f manifest/app/service.yaml -n handson
+kubectl apply -f manifest/app/ingress.yaml -n handson
 ```
 
-下記コマンドでデプロイされたリソースを確認できます。
+作成されるリソースは下記のとおりです。
 
 ```shell
-kubectl get -n handson all
+kubectl get services,deployments,ingresses -n handson
+```
+```sh
+# 実行結果
+NAME              TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+service/handson   ClusterIP   10.96.82.202   <none>        8080/TCP   3m33s
+
+NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/handson-blue   1/1     1            1           3m34s
+
+NAME                                             CLASS   HOSTS             ADDRESS       PORTS   AGE
+ingress.networking.k8s.io/app-ingress-by-nginx   nginx   app.example.com   10.96.54.28   80      3m9s
 ```
 
 ブラウザから`http://app.example.com`に接続し、下記のような画面が表示されることを確認してください。

--- a/chapter01_cluster-create/README.md
+++ b/chapter01_cluster-create/README.md
@@ -162,7 +162,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 ## アプリケーションのデプロイ
 次章以降で使用する動作確認用アプリケーションとして、[Argo Rollouts Demo Application](https://github.com/argoproj/rollouts-demo)をデプロイします。
 
-```shell
+```sh
 kubectl create namespace handson
 kubectl apply -f manifest/app/serviceaccount.yaml -n handson -l color=blue
 kubectl apply -f manifest/app/deployment.yaml -n handson -l color=blue
@@ -172,7 +172,7 @@ kubectl apply -f manifest/app/ingress.yaml -n handson
 
 作成されるリソースは下記のとおりです。
 
-```shell
+```sh
 kubectl get services,deployments,ingresses -n handson
 ```
 ```sh

--- a/chapter01_cluster-create/manifest/app/deployment.yaml
+++ b/chapter01_cluster-create/manifest/app/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         version: v1
         prometheus-monitor-ignore: ""
     spec:
-      serviceAccountName: handson
+      serviceAccountName: handson-blue
       containers:
       - image: argoproj/rollouts-demo:blue
         imagePullPolicy: IfNotPresent
@@ -93,7 +93,7 @@ spec:
         version: v1
         prometheus-monitor-ignore: ""
     spec:
-      serviceAccountName: handson
+      serviceAccountName: handson-yellow
       containers:
       - image: argoproj/rollouts-demo:yellow
         imagePullPolicy: IfNotPresent

--- a/chapter01_cluster-create/manifest/app/service.yaml
+++ b/chapter01_cluster-create/manifest/app/service.yaml
@@ -14,39 +14,3 @@ spec:
     targetPort: http
   selector:
     app: handson
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: handson
-  name: handson-blue
-spec:
-  type: ClusterIP
-  ports:
-  - port: 8080
-    protocol: TCP
-    targetPort: http
-    name: http-app
-  selector:
-    app: handson
-    color: blue
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: handson
-  name: handson-yellow
-spec:
-  type: ClusterIP
-  ports:
-  - port: 8080
-    protocol: TCP
-    targetPort: http
-    name: http-app
-  selector:
-    app: handson
-    color: yellow

--- a/chapter01_cluster-create/manifest/app/serviceaccount.yaml
+++ b/chapter01_cluster-create/manifest/app/serviceaccount.yaml
@@ -3,4 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
-  name: handson
+  name: handson-blue
+  labels:
+    color: blue
+---
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: false
+metadata:
+  name: handson-yellow
+  labels:
+    color: yellow


### PR DESCRIPTION
Issue: #182 

- Deployment manifestはblue, yellow同じファイルにして、kubectl apply時にラベル指定をしてデプロイの出し入れをできるようにしています(yellow imageはcilium, Istio chapterから呼び出し要)
- `handson-blue`, `handson-yellow` K8s svcに関してはcilium chapter(4d)でデプロイする想定のため、chapter1から削除しています


Issue目的とは外れますが、code block言語を`shell`から`sh`に変更しています。