### PR TITLE
Update README.md

### DIFF
--- a/chapter_kubevirt/README.md
+++ b/chapter_kubevirt/README.md
@@ -296,6 +296,13 @@ kubectl get pods -n cdi
 ```sh
 kubectl apply -f manifest/vm-with-datavolume.yaml
 
+# 仮想マシンを起動します。
+virtctl start vm-with-datavolume
+
+# StorageClass が WaitForFirstConsumer の場合、
+# 仮想マシンを起動しないと DataVolume の PHASE は
+# WaitForFirstConsumer から進みません。
+
 kubectl get datavolume
 # 以下のようにDatavolumeがSucceededになると成功です。
 # 今回DataVolumeではマニフェストの14行目にあるイメージをダウンロードしています。


### PR DESCRIPTION
chapter_kubevirt README の以下を修正しました。

- DataVolume の説明を補足

StorageClass が WaitForFirstConsumer の環境では、
VM を起動しないと DataVolume が Succeeded にならず
詰まったため、その補足説明を README に追記しました。
